### PR TITLE
feat: "multi" support for SocketConnector.serverToSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0
+- Added `multi` parameter to `SocketConnector.serverToSocket` - whether to
+  create new connections on the "B" side every time there is a new "A" side
+  connection to the bound server port. Also added `onConnect` parameter,
+  so that callers can be informed when every new connection is made, and
+  can thus take whatever action they require.
+
 ## 2.0.1
 - Removed an unnecessary dependency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   connection to the bound server port. Also added `onConnect` parameter,
   so that callers can be informed when every new connection is made, and
   can thus take whatever action they require.
+- feat: Added grace period so that SocketConnector doesn't close until both
+  (a) initial timeout has expired and (b) number of established connections
+  is zero or has dropped to zero
 
 ## 2.0.1
 - Removed an unnecessary dependency

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -375,9 +375,12 @@ class SocketConnector {
   /// - Binds to [portA] on [addressA]
   /// - Listens for a socket connection on [portA] port and joins it to
   ///   the 'B' side
-  ///
   /// - If [portA] is not provided then a port is chosen by the OS.
   /// - [addressA] defaults to [InternetAddress.anyIPv4]
+  /// - [multi] flag controls whether or not to allow multiple connections
+  ///   to the bound server port [portA]
+  /// - [onConnect] is called when [portA] has got a new connection and a
+  ///   corresponding outbound socket has been created to [addressB]:[portB]
   static Future<SocketConnector> serverToSocket(
       {
       /// Defaults to [InternetAddress.anyIPv4]

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -426,7 +426,7 @@ class SocketConnector {
       Side sideB = Side(sideBSocket, false, transformer: transformBtoA);
       unawaited(connector.handleSingleConnection(sideB));
 
-      unawaited(onConnect?.call(sideASocket, sideBSocket));
+      onConnect?.call(sideASocket, sideBSocket);
     });
 
     return (connector);

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -332,6 +332,7 @@ class SocketConnector {
   /// - Creates socket to [portB] on [addressB]
   /// - Relays data between the sockets
   static Future<SocketConnector> socketToSocket({
+    SocketConnector? connector,
     required InternetAddress addressA,
     required int portA,
     required InternetAddress addressB,
@@ -344,7 +345,7 @@ class SocketConnector {
     IOSink? logger,
   }) async {
     IOSink logSink = logger ?? stderr;
-    SocketConnector connector = SocketConnector(
+    connector ??= SocketConnector(
       verbose: verbose,
       logTraffic: logTraffic,
       timeout: timeout,

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -426,9 +426,7 @@ class SocketConnector {
       Side sideB = Side(sideBSocket, false, transformer: transformBtoA);
       unawaited(connector.handleSingleConnection(sideB));
 
-      Future.delayed(Duration(milliseconds: 0), () {
-        onConnect?.call(sideASocket, sideBSocket);
-      });
+      onConnect?.call(sideASocket, sideBSocket);
     });
 
     return (connector);

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -21,6 +21,8 @@ import 'package:socket_connector/src/types.dart';
 class SocketConnector {
   static const defaultTimeout = Duration(seconds: 30);
 
+  bool gracePeriodPassed = false;
+
   SocketConnector({
     this.verbose = false,
     this.logTraffic = false,
@@ -29,6 +31,7 @@ class SocketConnector {
   }) {
     this.logger = logger ?? stderr;
     Timer(timeout, () {
+      gracePeriodPassed = true;
       if (connections.isEmpty) {
         close();
       }
@@ -182,8 +185,9 @@ class SocketConnector {
       if (connectionToRemove != null) {
         connections.remove(connectionToRemove);
         _log(chalk.brightBlue('Removed connection'));
-        if (connections.isEmpty) {
-          _log(chalk.brightBlue('No established connections remain - '
+        if (connections.isEmpty && gracePeriodPassed) {
+          _log(chalk.brightBlue('No established connections remain'
+              ' and grace period has passed - '
               ' will close connector'));
           close();
         }

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -426,7 +426,9 @@ class SocketConnector {
       Side sideB = Side(sideBSocket, false, transformer: transformBtoA);
       unawaited(connector.handleSingleConnection(sideB));
 
-      onConnect?.call(sideASocket, sideBSocket);
+      Future.delayed(Duration(milliseconds: 0), () {
+        onConnect?.call(sideASocket, sideBSocket);
+      });
     });
 
     return (connector);

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -426,7 +426,7 @@ class SocketConnector {
       Side sideB = Side(sideBSocket, false, transformer: transformBtoA);
       unawaited(connector.handleSingleConnection(sideB));
 
-      onConnect?.call(sideASocket, sideBSocket);
+      unawaited(onConnect?.call(sideASocket, sideBSocket));
     });
 
     return (connector);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: socket_connector
-description: Package allows you to join two TCP clients or two servers this package includes all the tools you need to connect and optionally print the traffic.
+description: Package for joining sockets together to create socket relays.
 
-version: 2.0.1
+version: 2.1.0
 repository: https://github.com/cconstab/socket_connector
 
 environment:

--- a/test/socket_connector_test.dart
+++ b/test/socket_connector_test.dart
@@ -67,7 +67,8 @@ void main() {
     });
 
     test('Test ServerToServer', () async {
-      Duration timeout = Duration(milliseconds: 200);
+      int timeoutMs = 200;
+      Duration timeout = Duration(milliseconds: timeoutMs);
       SocketConnector connector = await SocketConnector.serverToServer(
         portA: 0,
         portB: 0,
@@ -118,12 +119,13 @@ void main() {
 
       socketB.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(Duration(milliseconds: timeoutMs)));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
 
     test('Test socketToServer', () async {
+      int timeoutMs = 100;
       // Bind to a port that SocketConnector.socketToServer can connect to
       ServerSocket testExternalServer = await ServerSocket.bind('127.0.0.1', 0);
 
@@ -131,7 +133,7 @@ void main() {
         addressA: testExternalServer.address,
         portA: testExternalServer.port,
         verbose: false,
-        timeout: Duration(milliseconds: 100),
+        timeout: Duration(milliseconds: timeoutMs),
       );
       expect(connector.connections.isEmpty, true);
 
@@ -176,12 +178,13 @@ void main() {
 
       socketB.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(Duration(milliseconds: timeoutMs)));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
 
     test('Test socketToSocket', () async {
+      int timeoutMs = 200;
       // Bind two ports that SocketConnector.socketToSocket can connect to
       ServerSocket testExternalServerA =
           await ServerSocket.bind('127.0.0.1', 0);
@@ -194,6 +197,7 @@ void main() {
         addressB: testExternalServerB.address,
         portB: testExternalServerB.port,
         verbose: false,
+        timeout: Duration(milliseconds: timeoutMs),
       );
 
       String rcvdA = '';
@@ -235,7 +239,7 @@ void main() {
 
       socketA.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(Duration(milliseconds: timeoutMs)));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
@@ -244,11 +248,12 @@ void main() {
       // Bind to a port that SocketConnector.serverToSocket can connect to
       ServerSocket testExternalServer = await ServerSocket.bind('127.0.0.1', 0);
 
+      int timeoutMs = 100;
       SocketConnector connector = await SocketConnector.serverToSocket(
         addressB: testExternalServer.address,
         portB: testExternalServer.port,
         verbose: false,
-        timeout: Duration(milliseconds: 100),
+        timeout: Duration(milliseconds: timeoutMs),
       );
       expect(connector.connections.isEmpty, true);
 
@@ -291,7 +296,7 @@ void main() {
 
       socketA.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(Duration(milliseconds: timeoutMs)));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
@@ -465,7 +470,7 @@ void main() {
 
       socketB.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(timeout));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
@@ -552,7 +557,7 @@ void main() {
 
       socketB.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(timeout));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
@@ -633,7 +638,7 @@ void main() {
       expect(connector.closed, false);
 
       authedB[2].destroy();
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(timeout));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
@@ -643,11 +648,12 @@ void main() {
       // Bind to a port that SocketConnector.socketToServer can connect to
       ServerSocket testExternalServer = await ServerSocket.bind('127.0.0.1', 0);
 
+      var timeout = Duration(milliseconds: 100);
       SocketConnector connector = await SocketConnector.socketToServer(
         addressA: testExternalServer.address,
         portA: testExternalServer.port,
         transformAtoB: reverser,
-        timeout: Duration(milliseconds: 100),
+        timeout: timeout,
       );
       expect(connector.connections.isEmpty, true);
 
@@ -690,12 +696,13 @@ void main() {
 
       socketB.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(timeout));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
 
     test('Test socketToSocket with two prefixing transformers', () async {
+      int timeoutMs = 100;
       // Bind two ports that SocketConnector.socketToSocket can connect to
       ServerSocket testExternalServerA =
           await ServerSocket.bind('127.0.0.1', 0);
@@ -709,6 +716,7 @@ void main() {
         addressB: testExternalServerB.address,
         portB: testExternalServerB.port,
         transformBtoA: bToA,
+        timeout: Duration(milliseconds: timeoutMs),
       );
 
       String rcvdA = '';
@@ -749,7 +757,7 @@ void main() {
 
       socketA.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(Duration(milliseconds: timeoutMs)));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });
@@ -759,12 +767,13 @@ void main() {
       // Bind to a port that SocketConnector.serverToSocket can connect to
       ServerSocket testExternalServer = await ServerSocket.bind('127.0.0.1', 0);
 
+      var timeout = Duration(milliseconds: 100);
       SocketConnector connector = await SocketConnector.serverToSocket(
         addressB: testExternalServer.address,
         portB: testExternalServer.port,
         transformAtoB: reverser,
         transformBtoA: reverser,
-        timeout: Duration(milliseconds: 100),
+        timeout: timeout,
       );
       expect(connector.connections.isEmpty, true);
 
@@ -804,7 +813,7 @@ void main() {
 
       socketA.destroy();
       // Wait for SocketConnector to handle the events
-      await (Future.delayed(Duration(milliseconds: 10)));
+      await (Future.delayed(timeout));
       expect(connector.closed, true);
       await connector.done.timeout(Duration.zero);
     });


### PR DESCRIPTION
**- What I did**
- Added `multi` parameter to `SocketConnector.serverToSocket` - whether to create new connections on the "B" side every time there is a new "A" side connection to the bound server port.
- Also added `onConnect` parameter, so that callers can be informed when every new connection is made, and can thus take whatever action they need to.
- feat: Added grace period so that SocketConnector doesn't close until both
  (a) initial timeout has expired and (b) number of established connections
  is zero or has dropped to zero
- build: updated version and CHANGELOG for v2.1.0
- test: added tests for `multi` feature

**- How to verify it**
Tests pass

