### PR TITLE
feat: Enhance serverToSocket to enable different transformers on each socket pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+- feat: Enhance serverToSocket adding optional parameter `beforeJoining` which
+  will be called before a socket pair is actually joined together. Thus,
+  different transformers can be used for each socket pair.
+
 ## 2.1.0
 - Added `multi` parameter to `SocketConnector.serverToSocket` - whether to
   create new connections on the "B" side every time there is a new "A" side

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -392,23 +392,23 @@ class SocketConnector {
   ///   but **before** they are joined together. This allows the code which
   ///   called [serverToSocket] to take additional steps (such as setting new
   ///   transformers rather than the ones which were provided initially)
-  static Future<SocketConnector> serverToSocket({
-    /// Defaults to [InternetAddress.anyIPv4]
-    InternetAddress? addressA,
-    int portA = 0,
-    required InternetAddress addressB,
-    required int portB,
-    DataTransformer? transformAtoB,
-    DataTransformer? transformBtoA,
-    bool verbose = false,
-    bool logTraffic = false,
-    Duration timeout = SocketConnector.defaultTimeout,
-    IOSink? logger,
-    bool multi = false,
-    @Deprecated("use beforeJoining instead")
-    Function(Socket socketA, Socket socketB)? onConnect,
-    Function(Side sideA, Side sideB)? beforeJoining,
-  }) async {
+  static Future<SocketConnector> serverToSocket(
+      {
+      /// Defaults to [InternetAddress.anyIPv4]
+      InternetAddress? addressA,
+      int portA = 0,
+      required InternetAddress addressB,
+      required int portB,
+      DataTransformer? transformAtoB,
+      DataTransformer? transformBtoA,
+      bool verbose = false,
+      bool logTraffic = false,
+      Duration timeout = SocketConnector.defaultTimeout,
+      IOSink? logger,
+      bool multi = false,
+      @Deprecated("use beforeJoining instead")
+      Function(Socket socketA, Socket socketB)? onConnect,
+      Function(Side sideA, Side sideB)? beforeJoining}) async {
     IOSink logSink = logger ?? stderr;
     addressA ??= InternetAddress.anyIPv4;
 

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -386,21 +386,29 @@ class SocketConnector {
   ///   to the bound server port [portA]
   /// - [onConnect] is called when [portA] has got a new connection and a
   ///   corresponding outbound socket has been created to [addressB]:[portB]
-  static Future<SocketConnector> serverToSocket(
-      {
-      /// Defaults to [InternetAddress.anyIPv4]
-      InternetAddress? addressA,
-      int portA = 0,
-      required InternetAddress addressB,
-      required int portB,
-      DataTransformer? transformAtoB,
-      DataTransformer? transformBtoA,
-      bool verbose = false,
-      bool logTraffic = false,
-      Duration timeout = SocketConnector.defaultTimeout,
-      IOSink? logger,
-      bool multi = false,
-      Function(Socket sideA, Socket sideB)? onConnect}) async {
+  ///   and the two have been joined together
+  /// - [beforeJoining] is called when [portA] has got a new connection and a
+  ///   corresponding outbound socket has been created to [addressB]:[portB]
+  ///   but **before** they are joined together. This allows the code which
+  ///   called [serverToSocket] to take additional steps (such as setting new
+  ///   transformers rather than the ones which were provided initially)
+  static Future<SocketConnector> serverToSocket({
+    /// Defaults to [InternetAddress.anyIPv4]
+    InternetAddress? addressA,
+    int portA = 0,
+    required InternetAddress addressB,
+    required int portB,
+    DataTransformer? transformAtoB,
+    DataTransformer? transformBtoA,
+    bool verbose = false,
+    bool logTraffic = false,
+    Duration timeout = SocketConnector.defaultTimeout,
+    IOSink? logger,
+    bool multi = false,
+    @Deprecated("use beforeJoining instead") Function(Socket socketA,
+        Socket socketB)? onConnect,
+    Function(Side sideA, Side sideB)? beforeJoining,
+  }) async {
     IOSink logSink = logger ?? stderr;
     addressA ??= InternetAddress.anyIPv4;
 
@@ -428,6 +436,7 @@ class SocketConnector {
       // connect to the side 'B' address and port
       Socket sideBSocket = await Socket.connect(addressB, portB);
       Side sideB = Side(sideBSocket, false, transformer: transformBtoA);
+      beforeJoining?.call(sideA, sideB);
       unawaited(connector.handleSingleConnection(sideB));
 
       onConnect?.call(sideASocket, sideBSocket);

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -405,8 +405,8 @@ class SocketConnector {
     Duration timeout = SocketConnector.defaultTimeout,
     IOSink? logger,
     bool multi = false,
-    @Deprecated("use beforeJoining instead") Function(Socket socketA,
-        Socket socketB)? onConnect,
+    @Deprecated("use beforeJoining instead")
+    Function(Socket socketA, Socket socketB)? onConnect,
     Function(Side sideA, Side sideB)? beforeJoining,
   }) async {
     IOSink logSink = logger ?? stderr;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: socket_connector
 description: Package for joining sockets together to create socket relays.
 
-version: 2.1.0
+version: 2.2.0
 repository: https://github.com/cconstab/socket_connector
 
 environment:

--- a/test/socket_connector_test.dart
+++ b/test/socket_connector_test.dart
@@ -312,9 +312,11 @@ void main() {
           verbose: true,
           timeout: Duration(milliseconds: 100),
           multi: true,
-          onConnect: (Socket sideA, Socket sideB) {
+          beforeJoining: (Side sideA, Side sideB) {
             serverConnections++;
             print('SocketConnector.serverToSocket onConnect called back');
+            sideA.transformer=aToB;
+            sideB.transformer=bToA;
           });
       expect(connector.connections.isEmpty, true);
 
@@ -357,14 +359,14 @@ void main() {
         // Wait for the sockets to send and receive data
         await Future.delayed(Duration(milliseconds: 10));
 
-        socketA.write('hello world from side A');
+        socketA.write('hello world');
         expect(currentSocketB != null, true);
-        currentSocketB?.write('hello world from side B');
+        currentSocketB?.write('hello world');
         // Wait for the sockets to send and receive data
         await Future.delayed(Duration(milliseconds: 10));
 
-        expect(rcvdA.last, "${aSockets.length}: hello world from side B");
-        expect(rcvdB.last, "${bSockets.length}: hello world from side A");
+        expect(rcvdA.last, "${aSockets.length}: from B: hello world");
+        expect(rcvdB.last, "${bSockets.length}: from A: hello world");
         expect(rcvdA.length, i + 1);
         expect(rcvdB.length, i + 1);
       }

--- a/test/socket_connector_test.dart
+++ b/test/socket_connector_test.dart
@@ -315,8 +315,8 @@ void main() {
           beforeJoining: (Side sideA, Side sideB) {
             serverConnections++;
             print('SocketConnector.serverToSocket onConnect called back');
-            sideA.transformer=aToB;
-            sideB.transformer=bToA;
+            sideA.transformer = aToB;
+            sideB.transformer = bToA;
           });
       expect(connector.connections.isEmpty, true);
 


### PR DESCRIPTION
**- What I did**
feat: Enhance serverToSocket adding optional parameter `beforeJoining` which will be called before a socket pair is actually joined together. Thus different transformers can be used for each socket pair.

**- How I did it**
See commit

**- How to verify it**
Tests pass