### PR TITLE
fix: improve stability under load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - fix: ensure serverToSocket handles sockets in strict sequence as they are
   accepted
+- fix: ensure that, when one side is closed, all data received from that side 
+  has been delivered to the other side before closing the other side
 
 ## 2.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.3
+
+- fix: ensure serverToSocket handles sockets in strict sequence as they are
+  accepted
+
 ## 2.3.2
 
 - fix: stability under load

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -276,7 +276,7 @@ class SocketConnector {
     pendingB.clear();
   }
 
-  void _log(String s, {bool force = false}) {
+  void _log(String s, {bool force = true}) {
     if (verbose || force) {
       logger.writeln('${DateTime.now()} | SocketConnector | $s');
     }

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -212,9 +212,9 @@ class SocketConnector {
     }
     side.state = SideState.closed;
 
-    try {
-      await side.stream.isEmpty;
-    } catch (_) {}
+    // try {
+    //   await side.stream.isEmpty;
+    // } catch (_) {}
     _log(chalk.brightBlue('_closeSide ${side.name}: RCVD: ${side.rcvd} bytes; SENT: ${side.sent} bytes'));
 
     Connection? connectionToRemove;

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -216,6 +216,7 @@ class SocketConnector {
     side.state = SideState.closed;
 
     if (waitAfterClose != null) {
+      _log(chalk.brightBlue('_closeSide ${side.name}: waiting for $waitAfterClose'));
       await Future.delayed(waitAfterClose!);
     }
     _log(chalk.brightBlue('_closeSide ${side.name}: RCVD: ${side.rcvd} bytes; SENT: ${side.sent} bytes'));
@@ -242,6 +243,7 @@ class SocketConnector {
 
     try {
       _log(chalk.brightBlue('Destroying socket on side ${side.name}'));
+      await side.socket.flush();
       side.socket.destroy();
       if (side.farSide != null && side.farSide!.state != SideState.closed) {
         if (side.rcvd == side.farSide!.sent) {
@@ -445,7 +447,6 @@ class SocketConnector {
     bool logTraffic = false,
     Duration timeout = SocketConnector.defaultTimeout,
     IOSink? logger,
-    Duration? waitAfterClose,
   }) async {
     IOSink logSink = logger ?? stderr;
     connector ??= SocketConnector(
@@ -453,7 +454,6 @@ class SocketConnector {
       logTraffic: logTraffic,
       timeout: timeout,
       logger: logSink,
-      waitAfterClose: waitAfterClose,
     );
 
     if (verbose) {

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -24,15 +24,12 @@ class SocketConnector {
 
   bool gracePeriodPassed = false;
 
-  Duration? waitAfterClose;
-
   SocketConnector({
     this.verbose = false,
     this.logTraffic = false,
     this.timeout = defaultTimeout,
     this.authTimeout = defaultTimeout,
     IOSink? logger,
-    this.waitAfterClose,
   }) {
     this.logger = logger ?? stderr;
     Timer(timeout, () {
@@ -215,10 +212,6 @@ class SocketConnector {
     }
     side.state = SideState.closed;
 
-    if (waitAfterClose != null) {
-      _log(chalk.brightBlue('_closeSide ${side.name}: waiting for $waitAfterClose'));
-      await Future.delayed(waitAfterClose!);
-    }
     _log(chalk.brightBlue('_closeSide ${side.name}: RCVD: ${side.rcvd} bytes; SENT: ${side.sent} bytes'));
 
     Connection? connectionToRemove;

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -98,6 +98,9 @@ class SocketConnector {
     if (closed) {
       throw StateError('Connector is closed');
     }
+    unawaited(thisSide.socket.done
+        .then((v) => _closeSide(thisSide))
+        .catchError((err) => _closeSide(thisSide)));
     if (thisSide.socketAuthVerifier == null) {
       thisSide.authenticated = true;
     } else {
@@ -120,7 +123,7 @@ class SocketConnector {
     }
     if (!thisSide.authenticated) {
       _log('Authentication failed on side ${thisSide.name}', force: true);
-      _destroySide(thisSide);
+      _closeSide(thisSide);
       return;
     }
 
@@ -137,31 +140,34 @@ class SocketConnector {
           'Added connection. There are now ${connections.length} connections.'));
 
       for (final side in [thisSide, thisSide.farSide!]) {
-        unawaited(side.socket.done
-            .then((v) => _destroySide(side))
-            .catchError((err) => _destroySide(side)));
         if (side.transformer != null) {
           // transformer is there to transform data originating FROM its side
+          // transformer's output will write to the SOCKET on the far side
           StreamController<Uint8List> sc = StreamController<Uint8List>();
           side.farSide!.sink = sc;
           Stream<List<int>> transformed = side.transformer!(sc.stream);
-          transformed.listen((data) {
-            try {
-              if (side.farSide!.state == SideState.open) {
+          transformed.listen(
+            (data) {
+              try {
                 side.farSide!.socket.add(data);
-              } else {
-                throw StateError(
-                    'Will not write to side ${side.farSide!.name} as its state is ${side.farSide!.state}');
+                side.farSide!.sent += data.length;
+                if (side.state == SideState.closed &&
+                    side.rcvd == side.farSide!.sent) {
+                  _closeSide(side.farSide!);
+                }
+              } catch (e, st) {
+                _log('Failed to write to side ${side.farSide!.name} - closing',
+                    force: true);
+                _log('(Error was $e; Stack trace follows\n$st', force: true);
+                _closeSide(side.farSide!);
               }
-            } catch (e, st) {
-              _log('Failed to write to side ${side.farSide!.name} - closing',
-                  force: true);
-              _log('(Error was $e; Stack trace follows\n$st');
-              _destroySide(side.farSide!);
-            }
-          });
+            },
+            onDone: () => _closeSide(side),
+            onError: (error) => _closeSide(side),
+          );
         }
         side.stream.listen((Uint8List data) {
+          side.rcvd += data.length;
           if (logTraffic) {
             final message = String.fromCharCodes(data);
             if (side.isSideA) {
@@ -173,34 +179,48 @@ class SocketConnector {
             }
           }
           try {
-            if (side.farSide!.state == SideState.open) {
-              side.farSide!.sink.add(data);
-            } else {
-              throw StateError(
-                  'Will not write to side ${side.farSide!.name} as its state is ${side.farSide!.state}');
+            side.farSide!.sink.add(data);
+            if (side.farSide!.sink is Socket) {
+              side.farSide!.sent += data.length;
+              if (side.state == SideState.closed &&
+                  side.rcvd == side.farSide!.sent) {
+                _closeSide(side.farSide!);
+              }
             }
           } catch (e, st) {
             _log('Failed to write to side ${side.farSide!.name} - closing',
                 force: true);
-            _log('(Error was $e; Stack trace follows\n$st');
-            _destroySide(side.farSide!);
+            _log('(Error was $e; Stack trace follows\n$st', force: true);
+            _closeSide(side.farSide!);
           }
-        }, onDone: () {
-          _log('stream.onDone on side ${side.name}');
-          _destroySide(side);
+        }, onDone: () async {
+          _log('${side.stream.runtimeType}.onDone on side ${side.name}');
+          _closeSide(side);
         }, onError: (error) {
-          _log('stream.onError on side ${side.name}: $error', force: true);
-          _destroySide(side);
+          _log(
+              '${side.stream.runtimeType}.onError on side ${side.name}: $error',
+              force: true);
+          _closeSide(side);
         });
       }
     }
   }
 
-  _destroySide(final Side side) {
+  _closeSide(final Side side) async {
     if (side.state != SideState.open) {
       return;
     }
-    side.state = SideState.closing;
+    side.state = SideState.closed;
+
+    try {
+      await side.stream.isEmpty;
+    } catch (_) {}
+    _log(chalk.brightBlue('_closeSide ${side.name}'));
+    _log(chalk.brightBlue(
+        '    Received ${side.rcvd} bytes; wrote ${side.farSide?.sent} bytes to far side'));
+    _log(chalk.brightBlue(
+        '    Received ${side.farSide!.rcvd} bytes from far side; wrote ${side.sent} bytes to this side'));
+
     Connection? connectionToRemove;
     for (final c in connections) {
       if (c.sideA == side || c.sideB == side) {
@@ -220,16 +240,23 @@ class SocketConnector {
         close();
       }
     }
-    side.state = SideState.closed;
+
     try {
       _log(chalk.brightBlue('Destroying socket on side ${side.name}'));
       side.socket.destroy();
-      if (side.farSide != null) {
-        _log(chalk.brightBlue(
-            'Destroying socket on far side (${side.farSide?.name})'));
-        _destroySide(side.farSide!);
+      if (side.farSide != null && side.farSide!.state != SideState.closed) {
+        if (side.rcvd == side.farSide!.sent) {
+          _log(chalk.brightBlue(
+              'Far side (${side.farSide?.name}) has received all data - will close it'));
+          _closeSide(side.farSide!);
+        } else {
+          _log(chalk.brightBlue(
+              'Far side (${side.farSide?.name}) has NOT YET received all data'));
+        }
       }
-    } catch (_) {}
+    } catch (err) {
+      _log('_closeSide encountered error $err');
+    }
   }
 
   void close() {
@@ -244,11 +271,11 @@ class SocketConnector {
       _log('closed');
     }
     for (final s in pendingA) {
-      _destroySide(s);
+      _closeSide(s);
     }
     pendingA.clear();
     for (final s in pendingB) {
-      _destroySide(s);
+      _closeSide(s);
     }
     pendingB.clear();
   }

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -281,7 +281,7 @@ class SocketConnector {
     pendingB.clear();
   }
 
-  void _log(String s, {bool force = true}) {
+  void _log(String s, {bool force = false}) {
     if (verbose || force) {
       logger.writeln('${DateTime.now()} | SocketConnector | $s');
     }

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -24,12 +24,15 @@ class SocketConnector {
 
   bool gracePeriodPassed = false;
 
+  Duration? waitAfterClose;
+
   SocketConnector({
     this.verbose = false,
     this.logTraffic = false,
     this.timeout = defaultTimeout,
     this.authTimeout = defaultTimeout,
     IOSink? logger,
+    this.waitAfterClose,
   }) {
     this.logger = logger ?? stderr;
     Timer(timeout, () {
@@ -212,9 +215,9 @@ class SocketConnector {
     }
     side.state = SideState.closed;
 
-    // try {
-    //   await side.stream.isEmpty;
-    // } catch (_) {}
+    if (waitAfterClose != null) {
+      await Future.delayed(waitAfterClose!);
+    }
     _log(chalk.brightBlue('_closeSide ${side.name}: RCVD: ${side.rcvd} bytes; SENT: ${side.sent} bytes'));
 
     Connection? connectionToRemove;
@@ -442,6 +445,7 @@ class SocketConnector {
     bool logTraffic = false,
     Duration timeout = SocketConnector.defaultTimeout,
     IOSink? logger,
+    Duration? waitAfterClose,
   }) async {
     IOSink logSink = logger ?? stderr;
     connector ??= SocketConnector(
@@ -449,6 +453,7 @@ class SocketConnector {
       logTraffic: logTraffic,
       timeout: timeout,
       logger: logSink,
+      waitAfterClose: waitAfterClose,
     );
 
     if (verbose) {

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -215,11 +215,7 @@ class SocketConnector {
     try {
       await side.stream.isEmpty;
     } catch (_) {}
-    _log(chalk.brightBlue('_closeSide ${side.name}'));
-    _log(chalk.brightBlue(
-        '    Received ${side.rcvd} bytes; wrote ${side.farSide?.sent} bytes to far side'));
-    _log(chalk.brightBlue(
-        '    Received ${side.farSide!.rcvd} bytes from far side; wrote ${side.sent} bytes to this side'));
+    _log(chalk.brightBlue('_closeSide ${side.name}: RCVD: ${side.rcvd} bytes; SENT: ${side.sent} bytes'));
 
     Connection? connectionToRemove;
     for (final c in connections) {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -65,6 +65,12 @@ class Side {
   SocketAuthVerifier? socketAuthVerifier;
   DataTransformer? transformer;
 
+  /// number of bytes written to this side's socket
+  int sent = 0;
+
+  /// number of bytes received from this side's socket
+  int rcvd = 0;
+
   String get name => isSideA ? 'A' : 'B';
   Side(this.socket, this.isSideA, {this.socketAuthVerifier, this.transformer}) {
     sink = socket;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: socket_connector
 description: Package for joining sockets together to create socket relays.
 
-version: 2.3.2
+version: 2.3.3
 repository: https://github.com/cconstab/socket_connector
 
 environment:
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   chalkdart: ^2.2.1
+  mutex: ^3.1.0
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
**- What I did**
- fix: ensure serverToSocket handles sockets in strict sequence as they are
  accepted
- fix: ensure that, when one side is closed, all data received from that side 
  has been delivered to the other side before closing the other side

**- How I did it**
- See comments on the file diffs

**- How to verify it**
- Tests pass here
- Verified under load via https://github.com/atsign-foundation/noports/pull/1509 by @cconstab @XavierChanth @gkc using various websites and concurrent load tests

**- Description for the changelog**
- fix: ensure serverToSocket handles sockets in strict sequence as they are
  accepted
- fix: ensure that, when one side is closed, all data received from that side 
  has been delivered to the other side before closing the other side
