### PR TITLE
feat: release 2.4.1 (added Stats to SocketConnector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.0
+## 2.4.1
 
 - feat: add `stats` method to SocketConnector; returns stats like number of
   sockets created in a session, bytes transferred in both directions, ip 

--- a/lib/socket_connector.dart
+++ b/lib/socket_connector.dart
@@ -1,4 +1,2 @@
-library socket_connector.dart;
-
 export 'package:socket_connector/src/socket_connector.dart';
 export 'package:socket_connector/src/types.dart';

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -24,6 +24,11 @@ class SocketConnector {
 
   bool gracePeriodPassed = false;
 
+  final StreamController<Connection> _csc =
+      StreamController<Connection>.broadcast();
+
+  Stream<Connection> get connectionStream => _csc.stream;
+
   SocketConnector({
     this.verbose = false,
     this.logTraffic = false,
@@ -138,6 +143,9 @@ class SocketConnector {
     if (pendingA.isNotEmpty && pendingB.isNotEmpty) {
       Connection c = Connection(pendingA.removeAt(0), pendingB.removeAt(0));
       connections.add(c);
+      if (!_csc.isClosed) {
+        _csc.add(c);
+      }
       stats.socketsSideA.add(HostAndPort(
         c.sideA.remoteHost,
         c.sideA.remotePort,
@@ -285,6 +293,7 @@ class SocketConnector {
 
     if (!_closedCompleter.isCompleted) {
       _closedCompleter.complete();
+      _csc.close();
       _log('closed');
     }
     for (final s in pendingA) {

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -147,15 +147,11 @@ class SocketConnector {
         _csc.add(c);
       }
       stats.socketsSideA.putIfAbsent(c.sideA.remoteHost, () => []);
-      stats.socketsSideA[c.sideA.remoteHost]!.add((
-        c.sideA.remotePort,
-        c.sideA.timestamp.toUtc().toIso8601String(),
-      ));
+      stats.socketsSideA[c.sideA.remoteHost]!.addAll(
+          [c.sideA.remotePort, c.sideA.timestamp.toUtc().toIso8601String()]);
       stats.socketsSideB.putIfAbsent(c.sideB.remoteHost, () => []);
-      stats.socketsSideB[c.sideB.remoteHost]!.add((
-        c.sideB.remotePort,
-        c.sideB.timestamp.toUtc().toIso8601String(),
-      ));
+      stats.socketsSideB[c.sideB.remoteHost]!.addAll(
+          [c.sideB.remotePort, c.sideB.timestamp.toUtc().toIso8601String()]);
       stats.numSocketPairs++;
       _log(chalk.brightBlue(
           'Added connection. There are now ${connections.length} connections.'));

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -138,8 +138,14 @@ class SocketConnector {
     if (pendingA.isNotEmpty && pendingB.isNotEmpty) {
       Connection c = Connection(pendingA.removeAt(0), pendingB.removeAt(0));
       connections.add(c);
-      stats.ipAddressesSideA.add(c.sideA.remoteAddress);
-      stats.ipAddressesSideB.add(c.sideB.remoteAddress);
+      stats.connectionsSideA.add(HostAndPort(
+        c.sideA.remoteHost,
+        c.sideA.remotePort,
+      ));
+      stats.connectionsSideB.add(HostAndPort(
+        c.sideB.remoteHost,
+        c.sideB.remotePort,
+      ));
       stats.numSocketPairs++;
       _log(chalk.brightBlue(
           'Added connection. There are now ${connections.length} connections.'));
@@ -208,7 +214,7 @@ class SocketConnector {
             _log('(Error was $e; Stack trace follows\n$st', force: true);
             _closeSide(side.farSide!);
           }
-        }, onDone: () async {
+        }, onDone: () {
           _log('${side.stream.runtimeType}.onDone on side ${side.name}');
           _closeSide(side);
         }, onError: (error) {
@@ -221,6 +227,7 @@ class SocketConnector {
     }
   }
 
+  // ignore: strict_top_level_inference
   _closeSide(final Side side) async {
     if (side.state != SideState.open) {
       return;

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -321,7 +321,6 @@ class SocketConnector {
     Duration timeout = SocketConnector.defaultTimeout,
     Duration authTimeout = SocketConnector.defaultTimeout,
     IOSink? logger,
-    Function(Side sideA, Side sideB)? beforeJoining,
     int backlog = 0,
   }) async {
     IOSink logSink = logger ?? stderr;

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -321,6 +321,7 @@ class SocketConnector {
     Duration timeout = SocketConnector.defaultTimeout,
     Duration authTimeout = SocketConnector.defaultTimeout,
     IOSink? logger,
+    Function(Side sideA, Side sideB)? beforeJoining,
     int backlog = 0,
   }) async {
     IOSink logSink = logger ?? stderr;

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -146,13 +146,15 @@ class SocketConnector {
       if (!_csc.isClosed) {
         _csc.add(c);
       }
-      stats.socketsSideA.add(HostAndPort(
+      stats.socketsSideA.add(SocketInfo(
         c.sideA.remoteHost,
         c.sideA.remotePort,
+        c.sideA.timestamp,
       ));
-      stats.socketsSideB.add(HostAndPort(
+      stats.socketsSideB.add(SocketInfo(
         c.sideB.remoteHost,
         c.sideB.remotePort,
+        c.sideB.timestamp,
       ));
       stats.numSocketPairs++;
       _log(chalk.brightBlue(

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -149,12 +149,12 @@ class SocketConnector {
       stats.socketsSideA.putIfAbsent(c.sideA.remoteHost, () => []);
       stats.socketsSideA[c.sideA.remoteHost]!.add((
         c.sideA.remotePort,
-        c.sideA.timestamp,
+        c.sideA.timestamp.toUtc().toIso8601String(),
       ));
       stats.socketsSideB.putIfAbsent(c.sideB.remoteHost, () => []);
       stats.socketsSideB[c.sideB.remoteHost]!.add((
         c.sideB.remotePort,
-        c.sideB.timestamp,
+        c.sideB.timestamp.toUtc().toIso8601String(),
       ));
       stats.numSocketPairs++;
       _log(chalk.brightBlue(

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -147,11 +147,12 @@ class SocketConnector {
         _csc.add(c);
       }
       stats.socketsSideA.putIfAbsent(c.sideA.remoteHost, () => []);
-      stats.socketsSideA[c.sideA.remoteHost]!.addAll(
-          [c.sideA.remotePort, c.sideA.timestamp.toUtc().toIso8601String()]);
+      stats.socketsSideA[c.sideA.remoteHost]!
+          .add(PortAndTimestamp(c.sideA.remotePort, c.sideA.timestamp));
+
       stats.socketsSideB.putIfAbsent(c.sideB.remoteHost, () => []);
-      stats.socketsSideB[c.sideB.remoteHost]!.addAll(
-          [c.sideB.remotePort, c.sideB.timestamp.toUtc().toIso8601String()]);
+      stats.socketsSideB[c.sideB.remoteHost]!
+          .add(PortAndTimestamp(c.sideB.remotePort, c.sideB.timestamp));
       stats.numSocketPairs++;
       _log(chalk.brightBlue(
           'Added connection. There are now ${connections.length} connections.'));

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -146,13 +146,13 @@ class SocketConnector {
       if (!_csc.isClosed) {
         _csc.add(c);
       }
-      stats.socketsSideA.add(SocketInfo(
-        c.sideA.remoteHost,
+      stats.socketsSideA.putIfAbsent(c.sideA.remoteHost, () => []);
+      stats.socketsSideA[c.sideA.remoteHost]!.add((
         c.sideA.remotePort,
         c.sideA.timestamp,
       ));
-      stats.socketsSideB.add(SocketInfo(
-        c.sideB.remoteHost,
+      stats.socketsSideB.putIfAbsent(c.sideB.remoteHost, () => []);
+      stats.socketsSideB[c.sideB.remoteHost]!.add((
         c.sideB.remotePort,
         c.sideB.timestamp,
       ));

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -138,11 +138,11 @@ class SocketConnector {
     if (pendingA.isNotEmpty && pendingB.isNotEmpty) {
       Connection c = Connection(pendingA.removeAt(0), pendingB.removeAt(0));
       connections.add(c);
-      stats.connectionsSideA.add(HostAndPort(
+      stats.socketsSideA.add(HostAndPort(
         c.sideA.remoteHost,
         c.sideA.remotePort,
       ));
-      stats.connectionsSideB.add(HostAndPort(
+      stats.socketsSideB.add(HostAndPort(
         c.sideB.remoteHost,
         c.sideB.remotePort,
       ));

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -92,9 +92,32 @@ class Side {
 
 enum SideState { open, closing, closed }
 
+class PortAndTimestamp {
+  final int port;
+  final DateTime timestamp;
+
+  PortAndTimestamp(this.port, this.timestamp);
+
+  Map<String, dynamic> toJson() => {
+        'port': port,
+        'timestamp': timestamp.toUtc().toIso8601String(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PortAndTimestamp &&
+          runtimeType == other.runtimeType &&
+          port == other.port &&
+          timestamp == other.timestamp;
+
+  @override
+  int get hashCode => Object.hash(port, timestamp);
+}
+
 class Stats {
-  final Map<String, List> socketsSideA = {};
-  final Map<String, List> socketsSideB = {};
+  final Map<String, List<PortAndTimestamp>> socketsSideA = {};
+  final Map<String, List<PortAndTimestamp>> socketsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -92,42 +92,16 @@ class Side {
 
 enum SideState { open, closing, closed }
 
-class SocketInfo {
-  final String host;
-  final int port;
-  final DateTime timestamp;
-
-  const SocketInfo(this.host, this.port, this.timestamp);
-
-  Map<String, dynamic> toJson() => {
-        'host': host,
-        'port': port,
-        'timestamp': timestamp.toUtc().toIso8601String(),
-      };
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is SocketInfo &&
-          runtimeType == other.runtimeType &&
-          host == other.host &&
-          port == other.port &&
-          timestamp == other.timestamp;
-
-  @override
-  int get hashCode => Object.hash(host, port, timestamp);
-}
-
 class Stats {
-  final Set<SocketInfo> socketsSideA = {};
-  final Set<SocketInfo> socketsSideB = {};
+  final Map<String, List<(int, DateTime)>> socketsSideA = {};
+  final Map<String, List<(int, DateTime)>> socketsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;
 
   Map<String, dynamic> toJson() => {
-        'socketsSideA': socketsSideA.toList(),
-        'socketsSideB': socketsSideB.toList(),
+        'socketsSideA': socketsSideA,
+        'socketsSideB': socketsSideB,
         'numSocketPairs': numSocketPairs,
         'bytesAtoB': bytesAtoB,
         'bytesBtoA': bytesBtoA,

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -93,8 +93,8 @@ class Side {
 enum SideState { open, closing, closed }
 
 class Stats {
-  final Map<String, List<(int, String)>> socketsSideA = {};
-  final Map<String, List<(int, String)>> socketsSideB = {};
+  final Map<String, List> socketsSideA = {};
+  final Map<String, List> socketsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -57,7 +57,8 @@ class Side {
   SideState state = SideState.open;
   bool isSideA;
   Socket socket;
-  late String remoteAddress;
+  late String remoteHost;
+  late int remotePort;
   late Stream<Uint8List> stream;
   late StreamSink<List<int>> sink;
   bool authenticated = false;
@@ -78,27 +79,67 @@ class Side {
     sink = socket;
     stream = socket;
     try {
-      remoteAddress = socket.remoteAddress.address;
+      remoteHost = socket.remoteAddress.address;
+      remotePort = socket.remotePort;
     } catch (e) {
-      remoteAddress = 'n/a';
+      remoteHost = 'n/a';
+      remotePort = -1;
     }
   }
 }
 
 enum SideState { open, closing, closed }
 
+class HostAndPort {
+  final String host;
+  final int port;
+
+  const HostAndPort(this.host, this.port);
+
+  Map<String, dynamic> toJson() => {
+        'host': host,
+        'port': port,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HostAndPort &&
+          runtimeType == other.runtimeType &&
+          host == other.host &&
+          port == other.port;
+
+  @override
+  int get hashCode => Object.hash(host, port);
+}
+
 class Stats {
-  final Set<String> ipAddressesSideA = {};
-  final Set<String> ipAddressesSideB = {};
+  final Set<HostAndPort> connectionsSideA = {};
+  final Set<HostAndPort> connectionsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;
 
   Map<String, dynamic> toJson() => {
-    'ipAddressesSideA': ipAddressesSideA.toList(),
-    'ipAddressesSideB': ipAddressesSideB.toList(),
-    'numSocketPairs': numSocketPairs,
-    'bytesAtoB': bytesAtoB,
-    'bytesBtoA': bytesBtoA,
-  };
+        'connectionsSideA': connectionsSideA.toList(),
+        'connectionsSideB': connectionsSideB.toList(),
+        'numSocketPairs': numSocketPairs,
+        'bytesAtoB': bytesAtoB,
+        'bytesBtoA': bytesBtoA,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Stats &&
+          runtimeType == other.runtimeType &&
+          connectionsSideA == other.connectionsSideA &&
+          connectionsSideB == other.connectionsSideB &&
+          numSocketPairs == other.numSocketPairs &&
+          bytesAtoB == other.bytesAtoB &&
+          bytesBtoA == other.bytesBtoA;
+
+  @override
+  int get hashCode => Object.hash(
+      connectionsSideA, connectionsSideB, numSocketPairs, bytesAtoB, bytesBtoA);
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -59,6 +59,7 @@ class Side {
   Socket socket;
   late String remoteHost;
   late int remotePort;
+  late DateTime timestamp;
   late Stream<Uint8List> stream;
   late StreamSink<List<int>> sink;
   bool authenticated = false;
@@ -76,6 +77,7 @@ class Side {
   String get name => isSideA ? 'A' : 'B';
 
   Side(this.socket, this.isSideA, {this.socketAuthVerifier, this.transformer}) {
+    timestamp = DateTime.now().toUtc();
     sink = socket;
     stream = socket;
     try {
@@ -90,32 +92,35 @@ class Side {
 
 enum SideState { open, closing, closed }
 
-class HostAndPort {
+class SocketInfo {
   final String host;
   final int port;
+  final DateTime timestamp;
 
-  const HostAndPort(this.host, this.port);
+  const SocketInfo(this.host, this.port, this.timestamp);
 
   Map<String, dynamic> toJson() => {
         'host': host,
         'port': port,
+        'timestamp': timestamp.toUtc().toIso8601String(),
       };
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is HostAndPort &&
+      other is SocketInfo &&
           runtimeType == other.runtimeType &&
           host == other.host &&
-          port == other.port;
+          port == other.port &&
+          timestamp == other.timestamp;
 
   @override
-  int get hashCode => Object.hash(host, port);
+  int get hashCode => Object.hash(host, port, timestamp);
 }
 
 class Stats {
-  final Set<HostAndPort> socketsSideA = {};
-  final Set<HostAndPort> socketsSideB = {};
+  final Set<SocketInfo> socketsSideA = {};
+  final Set<SocketInfo> socketsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -93,8 +93,8 @@ class Side {
 enum SideState { open, closing, closed }
 
 class Stats {
-  final Map<String, List<(int, DateTime)>> socketsSideA = {};
-  final Map<String, List<(int, DateTime)>> socketsSideB = {};
+  final Map<String, List<(int, String)>> socketsSideA = {};
+  final Map<String, List<(int, String)>> socketsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -114,15 +114,15 @@ class HostAndPort {
 }
 
 class Stats {
-  final Set<HostAndPort> connectionsSideA = {};
-  final Set<HostAndPort> connectionsSideB = {};
+  final Set<HostAndPort> socketsSideA = {};
+  final Set<HostAndPort> socketsSideB = {};
   int numSocketPairs = 0;
   int bytesAtoB = 0;
   int bytesBtoA = 0;
 
   Map<String, dynamic> toJson() => {
-        'connectionsSideA': connectionsSideA.toList(),
-        'connectionsSideB': connectionsSideB.toList(),
+        'socketsSideA': socketsSideA.toList(),
+        'socketsSideB': socketsSideB.toList(),
         'numSocketPairs': numSocketPairs,
         'bytesAtoB': bytesAtoB,
         'bytesBtoA': bytesBtoA,
@@ -133,13 +133,13 @@ class Stats {
       identical(this, other) ||
       other is Stats &&
           runtimeType == other.runtimeType &&
-          connectionsSideA == other.connectionsSideA &&
-          connectionsSideB == other.connectionsSideB &&
+          socketsSideA == other.socketsSideA &&
+          socketsSideB == other.socketsSideB &&
           numSocketPairs == other.numSocketPairs &&
           bytesAtoB == other.bytesAtoB &&
           bytesBtoA == other.bytesBtoA;
 
   @override
   int get hashCode => Object.hash(
-      connectionsSideA, connectionsSideB, numSocketPairs, bytesAtoB, bytesBtoA);
+      socketsSideA, socketsSideB, numSocketPairs, bytesAtoB, bytesBtoA);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: socket_connector
 description: Package for joining sockets together to create socket relays.
 
-version: 2.4.0
+version: 2.4.1
 repository: https://github.com/cconstab/socket_connector
 
 environment:
@@ -12,5 +12,5 @@ dependencies:
   mutex: ^3.1.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^6.0.0
   test: ^1.25.1


### PR DESCRIPTION
**- What I did**
- follow-on to https://github.com/atsign-foundation/socket_connector/pull/26 (2.4.0, which was published to pub.dev briefly before I retracted it)
- feat: 2.4.1 : put remoteHost and remotePort and timestamp into the Stats rather just the remoteHost; made better names
- SocketConnector provides `connectionStream` which emits a Connection every time a new Connection is made (two Sides have authenticated and been joined together)

**- How I did it**
- See commits, and comments on the file diffs

**- How to verify it**
- Tests pass
