### PR TITLE
feat: add configurable TCP keep-alive on all sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.5.0
+
+- feat: set TCP keep-alive options on every socket accepted or created. Enabled
+  by default (idle 60s, interval 10s, count 5); override via the new
+  `SocketKeepAlive` parameter on all `SocketConnector` factory methods
+- fix: `SocketConnector.gracePeriodPassed` is now a read-only getter (it used
+  to be a mutable field, so this is technically a breaking change, but mutable
+  never made any sense and nobody uses it that way)
+
 ## 2.4.1
 
 - feat: add `stats` method to SocketConnector; returns stats like number of

--- a/README.md
+++ b/README.md
@@ -23,20 +23,49 @@ all the tools you need to connect servers to servers and clients to clients.
 Why would you need this type of service? To create a rendezvous service that two
 clients can connect to for example or to join two servers with a shared client.
 Also included is a client to server, this acts as a simple TCP proxy and as with
-all the services you can optionally set the verbose flag in order to see 
-more info about what is happening, and the logTraffic flag in order to see the 
+all the services you can optionally set the verbose flag in order to see
+more info about what is happening, and the logTraffic flag in order to see the
 readable (ascii) characters that are being transmitted and received.
+
+The relay is created via one of four factory methods on `SocketConnector`,
+depending on whether each side is a server (something connects *to* us) or a
+client (we connect *out*):
+
+| Method           | Side A        | Side B        |
+|------------------|---------------|---------------|
+| `serverToServer` | binds/listens | binds/listens |
+| `serverToSocket` | binds/listens | connects out  |
+| `socketToServer` | connects out  | binds/listens |
+| `socketToSocket` | connects out  | connects out  |
+
+Other capabilities:
+
+- **Authentication** — pass a `SocketAuthVerifier` per side to gate a connection
+  before any data is relayed. See
+  [`example/socket_connector_with_authenticator.dart`](example/socket_connector_with_authenticator.dart).
+- **Transformers** — pass a `DataTransformer` (`transformAtoB` / `transformBtoA`)
+  to rewrite the byte stream in flight (compression, framing, etc.).
+- **Stats** — `connector.stats` reports sockets created, bytes relayed each way,
+  and the remote addresses seen during the session.
+- **Lifecycle** — `connector.connectionStream` emits each new `Connection`, and
+  `connector.done` completes when the connector closes. See
+  [`example/wait_for_connector_done_example.dart`](example/wait_for_connector_done_example.dart).
 
 ## Getting started
 
+```sh
 dart pub add socket_connector
+```
 
 ## Usage
 
 The following code will open two server sockets and connect them and display any
 traffic that goes between the sockets. You can test this using ncat to connect
 to the two listening ports in two sessions. You will see what is typed in one
-window appear in the other plus see the data on at the dart program.
+window appear in the other plus see the data via the Dart program.
+
+The snippets below assume `import 'dart:io';` (for `InternetAddress`) and
+`import 'package:socket_connector/socket_connector.dart';`.
 
 ```dart
   // Once running use ncat to check the sockets
@@ -58,6 +87,30 @@ window appear in the other plus see the data on at the dart program.
 
 [![asciicast](https://asciinema.org/a/cglnKVtH16DPwWfqGJXgPMCKn.svg)](https://asciinema.org/a/cglnKVtH16DPwWfqGJXgPMCKn)
 
+### TCP keep-alive
+
+Every socket the connector accepts or creates has TCP keep-alive enabled by
+default (idle 60s, interval 10s, count 5). Override it by passing a
+`SocketKeepAlive` to any of the factory methods (`serverToServer`,
+`socketToServer`, `socketToSocket`, `serverToSocket`):
+
+```dart
+  SocketConnector socketConnector = await SocketConnector.serverToServer(
+    addressA: InternetAddress.anyIPv4,
+    addressB: InternetAddress.anyIPv4,
+    portA: 9000,
+    portB: 8000,
+    keepAlive: SocketKeepAlive(
+      idleSeconds: 30,
+      intervalSeconds: 5,
+      probeCount: 4,
+    ),
+  );
+```
+
+Use `SocketKeepAlive.disabled` to turn keep-alive off. On Windows only
+`SO_KEEPALIVE` is set (with the system-default timings) because the per-probe
+tuning requires an ioctl that `dart:io` does not expose.
 
 ## Additional information
 
@@ -77,9 +130,3 @@ Excerpted from the SocketConnector class's documentation:
 /// - When [verbose] is true, log messages will be logged to [logger]
 /// - When [logTraffic] is true, socket traffic will be logged to [logger]
 ```
-
-TODO: Currently only `SocketConnector.serverToServer` handles more than one 
-pair of sockets in a given session; code needs to be added to `serverToSocket` 
-and `socketToServer` so that when a new connection is received to the 
-serverSocket, then a new connection is opened to the address and port on the 
-other side.

--- a/lib/src/socket_connector.dart
+++ b/lib/src/socket_connector.dart
@@ -5,28 +5,43 @@ import 'package:chalkdart/chalk.dart';
 import 'package:mutex/mutex.dart';
 import 'package:socket_connector/src/types.dart';
 
-/// Typical usage is via the [serverToServer], [serverToSocket],
-/// [socketToSocket] and [socketToServer] methods which are different flavours
-/// of the same functionality - to relay information from one socket to another.
+/// Relays data between two TCP sockets - a "side A" and a "side B".
 ///
-/// - Upon creation, a [Timer] will be created for [timeout] duration. The
-///   timer callback, when it executes, calls [close] if [connections]
-//    is empty
-/// - When an established connection is closed, [close] will be called if
-///   [connections] is empty
-/// - New [Connection]s are added to [connections] when both
-///   [pendingA] and [pendingB] have
-///   at least one entry
-/// - When [verbose] is true, log messages will be logged to [logger]
-/// - When [logTraffic] is true, socket traffic will be logged to [logger]
+/// Typical usage is via the [serverToServer], [serverToSocket],
+/// [socketToSocket] and [socketToServer] factory methods, which are different
+/// flavours of the same functionality - to relay information from one socket to
+/// another. Each side is either a server (something connects *to* it) or a
+/// client (it connects *out*); the four factories cover every combination.
+///
+/// - [timeout] sets a grace period that starts at construction. A one-shot
+///   [Timer] fires when it elapses (see [gracePeriodPassed]): if no
+///   [Connection] is established by then, [close] is called. Until the grace
+///   period elapses the connector stays open even with zero [connections],
+///   giving clients time to connect.
+/// - Once the grace period has elapsed, [close] is called as soon as the last
+///   established [Connection] closes (i.e. [connections] becomes empty).
+/// - New [Connection]s are added to [connections] when both [pendingA] and
+///   [pendingB] have at least one entry.
+/// - Each socket is given TCP keep-alive settings as it is accepted or created,
+///   per [keepAlive] (defaults to [SocketKeepAlive.defaults]).
+/// - When [verbose] is true, log messages are logged to [logger].
+/// - When [logTraffic] is true, socket traffic is logged to [logger].
+/// - [connectionStream] emits each new [Connection]; [done] completes when the
+///   connector closes; [stats] accumulates per-session counters.
 class SocketConnector {
   static const defaultTimeout = Duration(seconds: 30);
 
-  bool gracePeriodPassed = false;
+  bool _gracePeriodPassed = false;
+
+  /// Whether the [timeout] grace period has elapsed. While false, the connector
+  /// will not auto-close when [connections] is empty; once true, it closes as
+  /// soon as [connections] becomes empty.
+  bool get gracePeriodPassed => _gracePeriodPassed;
 
   final StreamController<Connection> _csc =
       StreamController<Connection>.broadcast();
 
+  /// Emits each new [Connection] as it is established.
   Stream<Connection> get connectionStream => _csc.stream;
 
   SocketConnector({
@@ -34,11 +49,12 @@ class SocketConnector {
     this.logTraffic = false,
     this.timeout = defaultTimeout,
     this.authTimeout = defaultTimeout,
+    this.keepAlive = SocketKeepAlive.defaults,
     IOSink? logger,
   }) {
     this.logger = logger ?? stderr;
     Timer(timeout, () {
-      gracePeriodPassed = true;
+      _gracePeriodPassed = true;
       if (connections.isEmpty) {
         close();
       }
@@ -54,8 +70,11 @@ class SocketConnector {
   /// When true, socket traffic will be logged to [logger]
   bool logTraffic;
 
-  /// - Upon creation, a [Timer] will be created for [timeout] duration. The timer
-  ///   callback calls [close] if [connections] is empty
+  /// The grace period, starting at construction, during which the connector
+  /// waits for connections without auto-closing. A one-shot [Timer] fires when
+  /// it elapses and calls [close] if no [Connection] is then established;
+  /// thereafter [close] is called whenever [connections] becomes empty.
+  /// See [gracePeriodPassed].
   final Duration timeout;
 
   /// The established [Connection]s
@@ -69,9 +88,12 @@ class SocketConnector {
   /// B [Side]s which are available for pairing with the next A side connections
   final List<Side> pendingB = [];
 
-  /// Completes when either
-  /// 1. [connections] size goes from >0 to 0, or
-  /// 2. [timeout] has passed and  [connections] is empty
+  /// Completes when the connector closes ([close] is called). That happens
+  /// when:
+  /// 1. the [timeout] grace period elapses with no established [Connection], or
+  /// 2. the last established [Connection] closes after the grace period has
+  ///    elapsed (see [gracePeriodPassed]), or
+  /// 3. [close] is called explicitly.
   Future get done => _closedCompleter.future;
 
   /// Whether this SocketConnector is closed or not
@@ -94,17 +116,33 @@ class SocketConnector {
   /// How long to wait for a client to authenticate its self
   final Duration authTimeout;
 
-  /// Add a [Side] with optional [SocketAuthVerifier] and
-  /// [DataTransformer]
-  /// - If [socketAuthVerifier] provided, wait for socket to be authenticated
-  /// - All data from the corresponding 'far' side will be transformed by the
-  ///   [transformer] if supplied. For example: [socketToSocket] creates a
-  ///   [Side]s A and B, and has parameters `transformAtoB` and
-  ///   `transformBtoA`.
+  /// TCP keep-alive settings applied to every socket this connector accepts
+  /// or creates. Defaults to [SocketKeepAlive.defaults].
+  final SocketKeepAlive keepAlive;
+
+  /// Brings [thisSide] under management: applies [keepAlive] to its socket,
+  /// optionally authenticates it, and pairs it with a [Side] from the opposite
+  /// side to form a [Connection].
+  ///
+  /// - [keepAlive] is applied to `thisSide.socket` first, so it takes effect
+  ///   even while authentication is in progress.
+  /// - If `thisSide.socketAuthVerifier` is set, the socket must authenticate
+  ///   within [authTimeout] before any data is relayed; on failure the side is
+  ///   closed.
+  /// - Once authenticated, the side is added to [pendingA] or [pendingB]; when
+  ///   both have an entry a [Connection] is formed and emitted on
+  ///   [connectionStream]. Data from each side is rewritten by that side's
+  ///   `transformer` (if any) before being written to the far side.
+  ///
+  /// Throws [StateError] if the connector is already [closed].
   Future<void> handleSingleConnection(final Side thisSide) async {
     if (closed) {
       throw StateError('Connector is closed');
     }
+    // Apply TCP keep-alive to every socket as it is accepted or created. Every
+    // Side - whether from an inbound accept or an outbound connect - funnels
+    // through here, so this is the single place keep-alive needs to be set.
+    keepAlive.applyTo(thisSide.socket, onError: (m) => _log(m, force: true));
     unawaited(thisSide.socket.done
         .then((v) => _closeSide(thisSide))
         .catchError((err) => _closeSide(thisSide)));
@@ -283,6 +321,8 @@ class SocketConnector {
     }
   }
 
+  /// Closes both server sockets (if any), closes every pending and established
+  /// side, completes [done] and closes [connectionStream]. Idempotent.
   void close() {
     _serverSocketA?.close();
     _serverSocketA = null;
@@ -311,9 +351,22 @@ class SocketConnector {
     }
   }
 
-  /// Binds two Server sockets on specified Internet Addresses.
-  /// Ports on which to listen can be given but if not given a spare port will be found by the OS.
-  /// Finally relays data between sockets and optionally displays contents using the verbose flag
+  /// Binds two server sockets, one on each side, and relays data between the
+  /// sockets that connect to them.
+  ///
+  /// - Side A listens on [addressA]:[portA], side B on [addressB]:[portB].
+  ///   Each address defaults to [InternetAddress.anyIPv4]; a port of `0` (the
+  ///   default) lets the OS choose a spare port - read the chosen ports back
+  ///   from [sideAPort] / [sideBPort].
+  /// - [socketAuthVerifierA] / [socketAuthVerifierB] optionally authenticate
+  ///   the connection on each side before any data is relayed.
+  /// - [keepAlive] sets TCP keep-alive on every accepted socket; defaults to
+  ///   [SocketKeepAlive.defaults].
+  /// - [backlog] is passed through to [ServerSocket.bind].
+  /// - [timeout] is the grace period during which the connector waits for
+  ///   connections before auto-closing; see [SocketConnector.timeout].
+  /// - Set [verbose] to log activity and [logTraffic] to log relayed bytes, to
+  ///   [logger] (defaults to stderr).
   static Future<SocketConnector> serverToServer({
     /// Defaults to [InternetAddress.anyIPv4]
     InternetAddress? addressA,
@@ -328,6 +381,7 @@ class SocketConnector {
     SocketAuthVerifier? socketAuthVerifierB,
     Duration timeout = SocketConnector.defaultTimeout,
     Duration authTimeout = SocketConnector.defaultTimeout,
+    SocketKeepAlive keepAlive = SocketKeepAlive.defaults,
     IOSink? logger,
     int backlog = 0,
   }) async {
@@ -340,6 +394,7 @@ class SocketConnector {
       logTraffic: logTraffic,
       timeout: timeout,
       authTimeout: authTimeout,
+      keepAlive: keepAlive,
       logger: logSink,
     );
     connector._serverSocketA = await ServerSocket.bind(
@@ -404,13 +459,21 @@ class SocketConnector {
     return (connector);
   }
 
-  /// - Creates socket to [portA] on [addressA]
-  /// - Binds to [portB] on [addressB]
-  /// - Listens for a socket connection on [portB] port and joins it to
-  ///   the 'A' side
+  /// Connects out for side A and listens for an inbound connection on side B,
+  /// then relays data between them.
   ///
-  /// - If [portB] is not provided then a port is chosen by the OS.
-  /// - [addressB] defaults to [InternetAddress.anyIPv4]
+  /// - Side A connects out to [addressA]:[portA].
+  /// - Side B binds and listens on [addressB]:[portB], and the inbound socket
+  ///   is joined to side A. If [portB] is `0` (the default) the OS chooses a
+  ///   spare port; [addressB] defaults to [InternetAddress.anyIPv4].
+  /// - [transformAtoB] / [transformBtoA] optionally rewrite the byte stream in
+  ///   each direction.
+  /// - [keepAlive] sets TCP keep-alive on every socket accepted or created;
+  ///   defaults to [SocketKeepAlive.defaults].
+  /// - [timeout] is the grace period during which the connector waits for
+  ///   connections before auto-closing; see [SocketConnector.timeout].
+  /// - Set [verbose] to log activity and [logTraffic] to log relayed bytes, to
+  ///   [logger] (defaults to stderr).
   static Future<SocketConnector> socketToServer({
     required InternetAddress addressA,
     required int portA,
@@ -423,6 +486,7 @@ class SocketConnector {
     bool verbose = false,
     bool logTraffic = false,
     Duration timeout = SocketConnector.defaultTimeout,
+    SocketKeepAlive keepAlive = SocketKeepAlive.defaults,
     IOSink? logger,
   }) async {
     IOSink logSink = logger ?? stderr;
@@ -432,6 +496,7 @@ class SocketConnector {
       verbose: verbose,
       logTraffic: logTraffic,
       timeout: timeout,
+      keepAlive: keepAlive,
       logger: logSink,
     );
 
@@ -456,9 +521,21 @@ class SocketConnector {
     return (connector);
   }
 
-  /// - Creates socket to [portA] on [addressA]
-  /// - Creates socket to [portB] on [addressB]
-  /// - Relays data between the sockets
+  /// Connects out on both sides and relays data between the two sockets.
+  ///
+  /// - Side A connects to [addressA]:[portA], side B to [addressB]:[portB].
+  /// - [transformAtoB] / [transformBtoA] optionally rewrite the byte stream in
+  ///   each direction.
+  /// - [keepAlive] sets TCP keep-alive on both created sockets; defaults to
+  ///   [SocketKeepAlive.defaults].
+  /// - Pass an existing [connector] to relay through it instead of creating a
+  ///   new one; when supplied, [verbose], [logTraffic], [timeout], [keepAlive]
+  ///   and [logger] are taken from that connector and the values passed here
+  ///   are ignored.
+  /// - [timeout] is the grace period during which the connector waits for
+  ///   connections before auto-closing; see [SocketConnector.timeout].
+  /// - Set [verbose] to log activity and [logTraffic] to log relayed bytes, to
+  ///   [logger] (defaults to stderr).
   static Future<SocketConnector> socketToSocket({
     SocketConnector? connector,
     required InternetAddress addressA,
@@ -470,6 +547,7 @@ class SocketConnector {
     bool verbose = false,
     bool logTraffic = false,
     Duration timeout = SocketConnector.defaultTimeout,
+    SocketKeepAlive keepAlive = SocketKeepAlive.defaults,
     IOSink? logger,
   }) async {
     IOSink logSink = logger ?? stderr;
@@ -477,6 +555,7 @@ class SocketConnector {
       verbose: verbose,
       logTraffic: logTraffic,
       timeout: timeout,
+      keepAlive: keepAlive,
       logger: logSink,
     );
 
@@ -504,22 +583,33 @@ class SocketConnector {
     return (connector);
   }
 
-  /// - Creates socket to [portB] on [addressB]
-  /// - Binds to [portA] on [addressA]
-  /// - Listens for a socket connection on [portA] port and joins it to
-  ///   the 'B' side
-  /// - If [portA] is not provided then a port is chosen by the OS.
-  /// - [addressA] defaults to [InternetAddress.anyIPv4]
-  /// - [multi] flag controls whether or not to allow multiple connections
-  ///   to the bound server port [portA]
-  /// - [onConnect] is called when [portA] has got a new connection and a
-  ///   corresponding outbound socket has been created to [addressB]:[portB]
-  ///   and the two have been joined together
-  /// - [beforeJoining] is called when [portA] has got a new connection and a
-  ///   corresponding outbound socket has been created to [addressB]:[portB]
-  ///   but **before** they are joined together. This allows the code which
-  ///   called [serverToSocket] to take additional steps (such as setting new
-  ///   transformers rather than the ones which were provided initially)
+  /// Listens for an inbound connection on side A and, for each one, connects
+  /// out on side B, then relays data between them.
+  ///
+  /// - Side A binds and listens on [addressA]:[portA]. If [portA] is `0` (the
+  ///   default) the OS chooses a spare port; [addressA] defaults to
+  ///   [InternetAddress.anyIPv4].
+  /// - For each inbound side A connection, side B connects out to
+  ///   [addressB]:[portB].
+  /// - [multi] controls whether more than one connection to the bound side A
+  ///   port [portA] is accepted; when false the server socket is closed after
+  ///   the first connection.
+  /// - [transformAtoB] / [transformBtoA] optionally rewrite the byte stream in
+  ///   each direction.
+  /// - [keepAlive] sets TCP keep-alive on every socket accepted or created;
+  ///   defaults to [SocketKeepAlive.defaults].
+  /// - [backlog] is passed through to [ServerSocket.bind].
+  /// - [beforeJoining] is called once side A has a new connection and the
+  ///   corresponding outbound side B socket to [addressB]:[portB] has been
+  ///   created, but **before** they are joined together. This lets the caller
+  ///   take additional steps (such as setting new transformers rather than the
+  ///   ones provided initially).
+  /// - [onConnect] is the deprecated equivalent of [beforeJoining], called
+  ///   **after** the two sides are joined.
+  /// - [timeout] is the grace period during which the connector waits for
+  ///   connections before auto-closing; see [SocketConnector.timeout].
+  /// - Set [verbose] to log activity and [logTraffic] to log relayed bytes, to
+  ///   [logger] (defaults to stderr).
   static Future<SocketConnector> serverToSocket(
       {
       /// Defaults to [InternetAddress.anyIPv4]
@@ -532,6 +622,7 @@ class SocketConnector {
       bool verbose = false,
       bool logTraffic = false,
       Duration timeout = SocketConnector.defaultTimeout,
+      SocketKeepAlive keepAlive = SocketKeepAlive.defaults,
       IOSink? logger,
       bool multi = false,
       @Deprecated("use beforeJoining instead")
@@ -545,6 +636,7 @@ class SocketConnector {
       verbose: verbose,
       logTraffic: logTraffic,
       timeout: timeout,
+      keepAlive: keepAlive,
       logger: logSink,
     );
 

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -92,6 +92,108 @@ class Side {
 
 enum SideState { open, closing, closed }
 
+/// TCP keep-alive configuration applied to every socket that a
+/// [SocketConnector] accepts or creates.
+///
+/// When [enable] is true, `SO_KEEPALIVE` is turned on and the per-connection
+/// probe timings are tuned:
+/// - probing starts after [idleSeconds] of idle time
+///   (`TCP_KEEPIDLE` on Linux/Android, `TCP_KEEPALIVE` on macOS/iOS),
+/// - a probe is then sent every [intervalSeconds] (`TCP_KEEPINTVL`),
+/// - and the connection is dropped after [probeCount] unacknowledged probes
+///   (`TCP_KEEPCNT`).
+///
+/// The package defaults are idle 60s, interval 10s, count 5; pass a custom
+/// instance to any of the [SocketConnector] factory methods to override.
+///
+/// On Windows only `SO_KEEPALIVE` is set (with the system-default timings),
+/// because the per-probe tuning requires the `SIO_KEEPALIVE_VALS` ioctl which
+/// `dart:io` does not expose.
+class SocketKeepAlive {
+  /// Whether `SO_KEEPALIVE` is enabled on the socket.
+  final bool enable;
+
+  /// Seconds a connection is idle before the first keep-alive probe is sent
+  /// (`TCP_KEEPIDLE` on Linux/Android, `TCP_KEEPALIVE` on macOS/iOS).
+  final int idleSeconds;
+
+  /// Seconds between successive keep-alive probes (`TCP_KEEPINTVL`).
+  final int intervalSeconds;
+
+  /// Number of unacknowledged probes before the connection is dropped
+  /// (`TCP_KEEPCNT`).
+  final int probeCount;
+
+  const SocketKeepAlive({
+    this.enable = true,
+    this.idleSeconds = 60,
+    this.intervalSeconds = 10,
+    this.probeCount = 5,
+  });
+
+  /// The package-wide defaults: enabled, idle 60s, interval 10s, count 5.
+  static const SocketKeepAlive defaults = SocketKeepAlive();
+
+  /// Keep-alive turned off entirely.
+  static const SocketKeepAlive disabled = SocketKeepAlive(enable: false);
+
+  /// Applies this configuration to [socket].
+  ///
+  /// Each option is set independently; a failure on one (e.g. an option the
+  /// running platform does not support) is reported via [onError] and does not
+  /// prevent the others from being applied.
+  void applyTo(Socket socket, {void Function(String message)? onError}) {
+    void warn(String message) {
+      if (onError != null) onError(message);
+    }
+
+    if (Platform.isMacOS || Platform.isIOS) {
+      // SOL_SOCKET = 0xffff, SO_KEEPALIVE = 0x0008
+      _trySet(socket, RawSocketOption.fromBool(0xffff, 0x0008, enable),
+          'SO_KEEPALIVE', warn);
+      if (enable) {
+        // IPPROTO_TCP = 6
+        _trySet(socket, RawSocketOption.fromInt(6, 0x10, idleSeconds),
+            'TCP_KEEPALIVE', warn);
+        _trySet(socket, RawSocketOption.fromInt(6, 0x101, intervalSeconds),
+            'TCP_KEEPINTVL', warn);
+        _trySet(socket, RawSocketOption.fromInt(6, 0x102, probeCount),
+            'TCP_KEEPCNT', warn);
+      }
+    } else if (Platform.isLinux || Platform.isAndroid) {
+      // SOL_SOCKET = 0x1, SO_KEEPALIVE = 0x0009
+      _trySet(socket, RawSocketOption.fromBool(0x1, 0x0009, enable),
+          'SO_KEEPALIVE', warn);
+      if (enable) {
+        // IPPROTO_TCP = 6
+        _trySet(socket, RawSocketOption.fromInt(6, 4, idleSeconds),
+            'TCP_KEEPIDLE', warn);
+        _trySet(socket, RawSocketOption.fromInt(6, 5, intervalSeconds),
+            'TCP_KEEPINTVL', warn);
+        _trySet(socket, RawSocketOption.fromInt(6, 6, probeCount),
+            'TCP_KEEPCNT', warn);
+      }
+    } else if (Platform.isWindows) {
+      // Only SO_KEEPALIVE can be set via setsockopt on Windows; the per-probe
+      // timings need the SIO_KEEPALIVE_VALS ioctl, which dart:io can't reach.
+      _trySet(socket, RawSocketOption.fromBool(0xffff, 0x0008, enable),
+          'SO_KEEPALIVE', warn);
+    } else {
+      warn('SocketKeepAlive: unsupported platform '
+          '${Platform.operatingSystem}');
+    }
+  }
+
+  void _trySet(Socket socket, RawSocketOption option, String name,
+      void Function(String) warn) {
+    try {
+      socket.setRawOption(option);
+    } catch (e) {
+      warn('SocketKeepAlive: failed to set $name: $e');
+    }
+  }
+}
+
 class PortAndTimestamp {
   final int port;
   final DateTime timestamp;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: socket_connector
 description: Package for joining sockets together to create socket relays.
 
-version: 2.4.1
-repository: https://github.com/cconstab/socket_connector
+version: 2.5.0
+repository: https://github.com/atsign-foundation/socket_connector
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/socket_connector_test.dart
+++ b/test/socket_connector_test.dart
@@ -820,6 +820,65 @@ void main() {
       await connector.done.timeout(Duration.zero);
     });
   });
+
+  group('Keepalive tests', () {
+    // SO_KEEPALIVE level/option differs by platform.
+    RawSocketOption keepAliveOption() {
+      if (Platform.isLinux || Platform.isAndroid) {
+        return RawSocketOption(
+            0x1, 0x0009, Uint8List(4)); // SOL_SOCKET/SO_KEEPALIVE
+      }
+      // macOS, iOS, Windows
+      return RawSocketOption(0xffff, 0x0008, Uint8List(4));
+    }
+
+    bool keepAliveEnabled(Socket socket) {
+      final value = socket.getRawOption(keepAliveOption());
+      return value.any((b) => b != 0);
+    }
+
+    Future<SocketConnector> connectPair(SocketKeepAlive keepAlive) async {
+      SocketConnector connector = await SocketConnector.serverToServer(
+        portA: 0,
+        portB: 0,
+        timeout: Duration(milliseconds: 500),
+        keepAlive: keepAlive,
+        verbose: false,
+      );
+      await Socket.connect('localhost', connector.sideAPort!);
+      await Socket.connect('localhost', connector.sideBPort!);
+      // Wait for SocketConnector to pair them into a Connection
+      await Future.delayed(Duration(milliseconds: 20));
+      expect(connector.connections.length, 1);
+      return connector;
+    }
+
+    test('Keepalive enabled by default on both sides', () async {
+      SocketConnector connector = await connectPair(SocketKeepAlive.defaults);
+      Connection c = connector.connections.first;
+      expect(keepAliveEnabled(c.sideA.socket), isTrue);
+      expect(keepAliveEnabled(c.sideB.socket), isTrue);
+      connector.close();
+      await connector.done;
+    });
+
+    test('Keepalive can be disabled via override', () async {
+      SocketConnector connector = await connectPair(SocketKeepAlive.disabled);
+      Connection c = connector.connections.first;
+      expect(keepAliveEnabled(c.sideA.socket), isFalse);
+      expect(keepAliveEnabled(c.sideB.socket), isFalse);
+      connector.close();
+      await connector.done;
+    });
+
+    test('SocketKeepAlive defaults are idle 60, interval 10, count 5', () {
+      const k = SocketKeepAlive.defaults;
+      expect(k.enable, isTrue);
+      expect(k.idleSeconds, 60);
+      expect(k.intervalSeconds, 10);
+      expect(k.probeCount, 5);
+    });
+  });
 }
 
 Stream<List<int>> addPrefix(Stream<List<int>> source,


### PR DESCRIPTION
## What

Enable TCP keep-alive on every socket the connector accepts or creates, applied in the single `handleSingleConnection` funnel so each socket is covered exactly once.

- Defaults to **idle 60s / interval 10s / count 5**.
- Override via the new `SocketKeepAlive` parameter on all four factory methods (`serverToServer`, `socketToServer`, `socketToSocket`, `serverToSocket`) and the `SocketConnector` constructor.
- `SocketKeepAlive.disabled` turns it off.
- Per-platform raw socket options for macOS/iOS and Linux/Android; Windows enables `SO_KEEPALIVE` only (per-probe tuning needs an ioctl `dart:io` can't reach). Each option is set independently so an unsupported one warns rather than aborting the rest.

## Why

Long-lived relayed connections can silently die (NAT timeout, peer crash) with no FIN/RST; keep-alive lets the OS detect and tear down dead peers.

## Also in this PR

- **fix:** `SocketConnector.gracePeriodPassed` is now a read-only getter. It used to be a mutable public field, so this is technically a breaking change, but mutable never made any sense and nobody uses it that way.
- Corrected/expanded dartdocs on the class, the four factories, and public members — including fixing the grace-period docs that omitted the `gracePeriodPassed` gate.
- README: documented keep-alive, added a four-method table, added auth/transformer/stats sections, removed a stale TODO, misc fixes.
- Fixed the `pubspec.yaml` `repository` URL to `atsign-foundation/socket_connector`.

## Tests

Added a `Keepalive` test group: verifies `SO_KEEPALIVE` is actually enabled by default and disabled via override (round-tripped through `getRawOption`), plus a defaults check. Full suite (18 tests) passes with `--concurrency=1`.